### PR TITLE
added option to initialize database without demo data

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,16 @@ invoke img-build --pull
 invoke git-aggregate
 ```
 
-Initialize a new empty database with:
+Initialize a new empty database without demo data:
 
 ```bash
 invoke resetdb
 ```
 
-Initialize a new empty database without demo data:
+Initialize a new empty database with demo data:
 
 ```bash
-invoke resetdb --nodemo
+invoke resetdb --demo
 ```
 
 Start Odoo with:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Initialize a new empty database with:
 invoke resetdb
 ```
 
+Initialize a new empty database without demo data:
+
+```bash
+invoke resetdb --nodemo
+```
+
 Start Odoo with:
 
 ```bash

--- a/tasks.py
+++ b/tasks.py
@@ -813,7 +813,6 @@ def resetdb(
             demo_option = "--no-demo"
 
         c.run(
-            # f"{_run} click-odoo-initdb -n {dbname} -m {modules} {additional_option}",
             f"{_run} click-odoo-initdb -n {dbname} -m {modules} {demo_option}",
             env=UID_ENV,
             pty=True,

--- a/tasks.py
+++ b/tasks.py
@@ -806,12 +806,12 @@ def resetdb(
             warn=True,
             pty=True,
         )
-        no_demo_option = ""
+        additional_option = ""
         if nodemo:
-            no_demo_option = "--no-demo"
+            additional_option = "--no-demo"
 
         c.run(
-            f"{_run} click-odoo-initdb -n {dbname} -m {modules} {no_demo_option}",
+            f"{_run} click-odoo-initdb -n {dbname} -m {modules} {additional_option}",
             env=UID_ENV,
             pty=True,
         )

--- a/tasks.py
+++ b/tasks.py
@@ -784,7 +784,7 @@ def resetdb(
     dbname="devel",
     populate=True,
     dependencies=False,
-    nodemo=False,
+    demo=False,
 ):
     """Reset the specified database with the specified modules.
 
@@ -806,12 +806,15 @@ def resetdb(
             warn=True,
             pty=True,
         )
-        additional_option = ""
-        if nodemo:
-            additional_option = "--no-demo"
+
+        if demo:
+            demo_option = "--demo"
+        else:
+            demo_option = "--no-demo"
 
         c.run(
-            f"{_run} click-odoo-initdb -n {dbname} -m {modules} {additional_option}",
+            # f"{_run} click-odoo-initdb -n {dbname} -m {modules} {additional_option}",
+            f"{_run} click-odoo-initdb -n {dbname} -m {modules} {demo_option}",
             env=UID_ENV,
             pty=True,
         )

--- a/tasks.py
+++ b/tasks.py
@@ -784,6 +784,7 @@ def resetdb(
     dbname="devel",
     populate=True,
     dependencies=False,
+    nodemo=False,
 ):
     """Reset the specified database with the specified modules.
 
@@ -805,8 +806,12 @@ def resetdb(
             warn=True,
             pty=True,
         )
+        no_demo_option = ""
+        if nodemo:
+            no_demo_option = "--no-demo"
+
         c.run(
-            f"{_run} click-odoo-initdb -n {dbname} -m {modules}",
+            f"{_run} click-odoo-initdb -n {dbname} -m {modules} {no_demo_option}",
             env=UID_ENV,
             pty=True,
         )


### PR DESCRIPTION
- Added new parameter in resetdb named demo and default is False
- use "invoke resetdb --demo" to initialize a db with demo data
- use "invoke resetdb" to initialize a db without demo data
- updated README.md