### PR TITLE
able to initialize and not initialize demo data in invoke resetdb

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -836,6 +836,7 @@ def resetdb(
     dbname="devel",
     populate=True,
     dependencies=False,
+    demo=False,
 ):
     """Reset the specified database with the specified modules.
 
@@ -857,8 +858,14 @@ def resetdb(
             warn=True,
             pty=True,
         )
+
+        if demo:
+            demo_option = "--demo"
+        else:
+            demo_option = "--no-demo"
+
         c.run(
-            f"{_run} click-odoo-initdb -n {dbname} -m {modules}",
+            f"{_run} click-odoo-initdb -n {dbname} -m {modules} {demo_option}",
             env=UID_ENV,
             pty=True,
         )


### PR DESCRIPTION
To initialize a new empty database with demo data, use below invoke command
```
invoke resetdb --demo
```

To onitialize a new empty database without demo data, just remove the `--demo`

```
invoke resetdb
```