### PR TITLE
Openspp 17.0.1.2

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -20,7 +20,7 @@ odoo_initial_lang: en_US
 odoo_listdb: false
 odoo_oci_image: openspp/openspp
 odoo_proxy: traefik
-odoo_version: 15.0
+odoo_version: 17.0
 paths_without_crawlers:
   - /
 postgres_cidr_whitelist: null
@@ -28,7 +28,7 @@ postgres_dbname: prod
 postgres_exposed: false
 postgres_exposed_port: 5432
 postgres_username: odoo
-postgres_version: "13"
+postgres_version: "15"
 project_author: OpenSPP
 project_license: LGPL-3.0-or-later
 project_name: OpenSPP

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -6,7 +6,7 @@ score=n
 readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
 manifest_required_keys=license
 manifest_deprecated_keys=active
-valid_odoo_versions=15.0
+valid_odoo_versions=17.0
 
 [MESSAGES CONTROL]
 disable=all

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 [![Apache-2.0 license](https://img.shields.io/badge/license-Apache--2.0-success})](LICENSE)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
 
-# OpenSPP 
+# OpenSPP
 
 The quick start guide is located [here](https://docs.openspp.org/getting_started/installation_guide.html).
+
+Adjust the openspp-modules branch in `odoo/custom/src/repos.yaml` to the desired branch.
+Currently, the OpenSPP Batanes release (17.0.1.2.1) is used.
 
 This project is a Doodba scaffolding. Check upstream docs on the matter:
 

--- a/devel.yaml
+++ b/devel.yaml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   odoo_proxy:
     platform: linux/amd64

--- a/odoo/Dockerfile
+++ b/odoo/Dockerfile
@@ -1,2 +1,2 @@
-ARG ODOO_VERSION
+ARG ODOO_VERSION=17.0
 FROM ghcr.io/tecnativa/doodba:${ODOO_VERSION}-onbuild

--- a/odoo/custom/dependencies/pip.txt
+++ b/odoo/custom/dependencies/pip.txt
@@ -1,8 +1,8 @@
 git+https://github.com/OCA/openupgradelib.git@master
 unicodecsv
 unidecode
-twilio==7.9.2
-boto3==1.24.2
+twilio>=9.2.4
+boto3>=1.35.12
 celery
 flower
 faker

--- a/odoo/custom/dependencies/pip.txt
+++ b/odoo/custom/dependencies/pip.txt
@@ -1,17 +1,16 @@
 git+https://github.com/OCA/openupgradelib.git@master
-unicodecsv
-unidecode
-twilio>=9.2.4
 boto3>=1.35.12
 celery
-flower
 faker
+flower
 python-jose==3.3.0
+twilio>=9.2.4
+unicodecsv
+unidecode
 
 # REST API dependencies
-cachetools
-pydantic
 apispec>=4.0.0
+cachetools
 cerberus
 extendable
 extendable-pydantic
@@ -20,9 +19,10 @@ marshmallow
 marshmallow-objects>=2.0.0
 parse-accept-language
 pydantic
+pydantic
 pyquerystring
-typing-extensions
 schwifty
+typing-extensions
 
 # Geo dependencies
 geojson
@@ -35,6 +35,7 @@ Pillow>=10.3.0
 PyLD
 bravado_core
 faker
+fastapi==0.112.2
 geojson
 jsonschema
 jwcrypto

--- a/odoo/custom/dependencies/pip.txt
+++ b/odoo/custom/dependencies/pip.txt
@@ -29,3 +29,23 @@ geojson
 shapely
 simplejson
 pyproj
+
+# OpenSPP dependencies
+Pillow>=10.3.0
+PyLD
+bravado_core
+faker
+geojson
+jsonschema
+jwcrypto
+numpy>=1.22.2
+pyjwt>=2.4.0
+pyproj
+python-magic
+qrcode
+shapely
+simplejson
+swagger_spec_validator
+urllib3>=2.2.2
+xlrd
+zipp>=3.19.1

--- a/odoo/custom/src/addons.yaml
+++ b/odoo/custom/src/addons.yaml
@@ -16,3 +16,5 @@ queue:
   - queue_job
 muk_addons:
   - "*"
+server-backend:
+  - "*"

--- a/odoo/custom/src/addons.yaml
+++ b/odoo/custom/src/addons.yaml
@@ -4,54 +4,11 @@ openg2p_program:
   - "*"
 openspp_modules:
   - "*"
-#openspp_program:
-#  - "*"
-#openspp_communication:
-#  - "*"
-#openspp_theme:
-#  - "*"
-#openspp_grievance_redress_mechanism:
-#  - "*"
-#openspp_demo:
-#  - "*"
-#openspp_dms:
-#  - "*"
-#helpdesk:
-#  - helpdesk_mgmt
 server-tools:
   - base_multi_image
 server-ux:
   - mass_editing
 queue:
   - queue_job
-#server-auth:
-#  - auth_oidc
-#  - auth_api_key
-#rest-framework:
-#  - "*"
-#connector:
-#  - component
-#smile-odoo:
-#  - smile_audit
-#openspp_odoo_external_dependencies:
-#  - "*"
-#web:
-#  - web_advanced_search
-#  - web_dialog_size
-#  - web_responsive
-#  - web_m2x_options
-#  - web_m2x_options_manager
-#  - web_widget_domain_editor_dialog
-#  - web_domain_field
-#  - web_drop_target
-# dms:
-#   - dms
-#   - dms_field
-#cybro_addons:
-#  - "*"
 muk_addons:
   - "*"
-#social:
-#  - "*"
-#app-odoo:
-#  - "*"

--- a/odoo/custom/src/addons.yaml
+++ b/odoo/custom/src/addons.yaml
@@ -2,6 +2,10 @@ openg2p_registry:
   - "*"
 openg2p_program:
   - "*"
+openg2p_rest_framework:
+  - "fastapi"
+  - "extendable"
+  - "extendable_fastapi"
 openspp_modules:
   - "*"
 server-tools:

--- a/odoo/custom/src/repos.yaml
+++ b/odoo/custom/src/repos.yaml
@@ -6,7 +6,6 @@
     # for a sane value of 100 commits)
     depth: $DEPTH_DEFAULT
   remotes:
-    ocb: https://github.com/OCA/OCB.git
     odoo: https://github.com/odoo/odoo.git
     openupgrade: https://github.com/OCA/OpenUpgrade.git
   target: odoo $ODOO_VERSION
@@ -25,7 +24,7 @@ openg2p_registry:
     openg2p: https://github.com/OpenSPP/openg2p-registry.git
   target: openg2p $ODOO_VERSION
   merges:
-    - openg2p 17.0-develop
+    - openg2p 17.0-develop-openspp
     # Example of a merge of the PR with the number <PR>
     # - oca refs/pull/<PR>/head
 
@@ -39,7 +38,35 @@ openg2p_program:
     openg2p: https://github.com/OpenSPP/openg2p-program.git
   target: openg2p $ODOO_VERSION
   merges:
-    - openg2p 17.0-develop
+    - openg2p 17.0-develop-openspp
+    # Example of a merge of the PR with the number <PR>
+    # - oca refs/pull/<PR>/head
+
+openg2p_rest_framework:
+  defaults:
+    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
+    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
+    # for a sane value of 100 commits)
+    depth: 1
+  remotes:
+    openg2p: https://github.com/OpenSPP/openg2p-rest-framework.git
+  target: openg2p 17.0-openspp
+  merges:
+    - openg2p 17.0-openspp
+    # Example of a merge of the PR with the number <PR>
+    # - oca refs/pull/<PR>/head
+
+openg2p_auth:
+  defaults:
+    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
+    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
+    # for a sane value of 100 commits)
+    depth: 1
+  remotes:
+    openg2p: https://github.com/OpenSPP/openg2p-auth.git
+  target: openg2p 17.0-develop-openspp
+  merges:
+    - openg2p 17.0-develop-openspp
     # Example of a merge of the PR with the number <PR>
     # - oca refs/pull/<PR>/head
 
@@ -51,13 +78,41 @@ openspp_modules:
     depth: $DEPTH_DEFAULT
   remotes:
     openspp: https://github.com/openspp/openspp-modules.git
-  target: openspp $ODOO_VERSION
+  target: openspp openspp-17.0.1.2.1
   merges:
-    - openspp 17.0
+    - openspp openspp-17.0.1.2.1
 
 muk_addons:
   remotes:
     muk: https://github.com/OpenSPP/mukit-modules.git
   target: muk $ODOO_VERSION
   merges:
-    - muk 17.0
+    - muk 17.0-openspp
+
+server-ux:
+  remotes:
+    OCA: https://github.com/OCA/server-ux.git
+  target: OCA 17.0
+  merges:
+    - OCA 17.0
+
+server-tools:
+  remotes:
+    OCA: https://github.com/OCA/server-tools.git
+  target: OCA 17.0
+  merges:
+    - OCA 17.0
+
+queue:
+  remotes:
+    OCA: https://github.com/OCA/queue.git
+  target: OCA 17.0
+  merges:
+    - OCA 17.0
+
+server-backend:
+  remotes:
+    OCA: https://github.com/OCA/server-backend.git
+  target: OCA 17.0
+  merges:
+    - OCA 17.0

--- a/odoo/custom/src/repos.yaml
+++ b/odoo/custom/src/repos.yaml
@@ -22,12 +22,13 @@ openg2p_registry:
     # for a sane value of 100 commits)
     depth: $DEPTH_DEFAULT
   remotes:
-    openg2p: https://github.com/OpenG2P/openg2p-registry.git
-  target: openg2p 17.0-develop
+    openg2p: https://github.com/OpenSPP/openg2p-registry.git
+  target: openg2p $ODOO_VERSION
   merges:
     - openg2p 17.0-develop
     # Example of a merge of the PR with the number <PR>
     # - oca refs/pull/<PR>/head
+
 openg2p_program:
   defaults:
     # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
@@ -35,12 +36,13 @@ openg2p_program:
     # for a sane value of 100 commits)
     depth: $DEPTH_DEFAULT
   remotes:
-    openg2p: https://github.com/OpenG2P/openg2p-program.git
-  target: openg2p 17.0-develop
+    openg2p: https://github.com/OpenSPP/openg2p-program.git
+  target: openg2p $ODOO_VERSION
   merges:
     - openg2p 17.0-develop
     # Example of a merge of the PR with the number <PR>
     # - oca refs/pull/<PR>/head
+
 openspp_modules:
   defaults:
     # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
@@ -51,198 +53,11 @@ openspp_modules:
     openspp: https://github.com/openspp/openspp-modules.git
   target: openspp $ODOO_VERSION
   merges:
-    - openspp $ODOO_VERSION
-    # Example of a merge of the PR with the number <PR>
-    # - oca refs/pull/<PR>/head
-#odoo-cloud-platform:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    redis: https://github.com/camptocamp/odoo-cloud-platform.git
-#  target: redis 15.0
-#  merges:
-#    - redis 1731912ba4c1d48b61d092beacd0105fb162a0ef
-#openspp_program:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    openspp: https://github.com/openspp/openspp-program.git
-#  target: openspp 15.1.1
-#  merges:
-#    - openspp 15.1.1
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#openspp_communication:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    openspp: https://github.com/openspp/openspp-communication.git
-#  target: openspp 15.0
-#  merges:
-#    - openspp 15.0
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#openspp_grievance_redress_mechanism:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    openspp: https://github.com/openspp/openspp-grievance-redress-mechanism.git
-#  target: openspp 15.0
-#  merges:
-#    - openspp 15.0
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#openspp_dms:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    openspp: https://github.com/OpenSPP/openspp-dms.git
-#  target: openspp 15.0
-#  merges:
-#    - openspp 15.0
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#openspp_demo:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    openspp: https://github.com/openspp/openspp-demo.git
-#  target: openspp 15.1.1
-#  merges:
-#    - openspp 15.1.1
-#    - openspp refs/pull/52/head
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#openspp_theme:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    openspp: https://github.com/openspp/openspp-theme.git
-#  target: openspp 15.0
-#  merges:
-#    - openspp 15.0
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#server-auth:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    oca: https://github.com/OCA/server-auth.git
-#  target: oca 15.0
-#  merges:
-#    - oca 0d6f847d3f13570a44c435634f289e2f5ca1a15c
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#rest-framework:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    oca: https://github.com/OCA/rest-framework.git
-#    newlogic: https://github.com/newlogic/oca-rest-framework.git
-#  target: oca 15.0
-#  merges:
-#    - oca 780fb402de43f571206f7c302b14f2e21bf52468
-#    - newlogic fix-schema-alias
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#smile-odoo:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    smile: https://github.com/Smile-SA/odoo_addons.git
-#  target: smile 15.0
-#  merges:
-#    - smile 2ec3aafa8b6d7eb81ce987778464d8acd5464219
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#openspp_odoo_external_dependencies:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    openspp: https://github.com/openspp/openspp-odoo-external-dependencies.git
-#  target: openspp 15.0
-#  merges:
-#    - openspp 15.0
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#queue:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    oca: https://github.com/OCA/queue.git
-#  target: oca 15.0
-#  merges:
-#    - oca bab89cfc916308eb17285fdb241ec7865c6980b6
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#dms:
-#  defaults:
-#    # Shallow repositories ($DEPTH_DEFAULT=1) are faster & thinner
-#    # You may need a bigger depth when merging PRs (use $DEPTH_MERGE
-#    # for a sane value of 100 commits)
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    oca: https://github.com/OCA/dms.git
-#  target: oca 15.0
-#  merges:
-#    - oca 07e0fef79d6985d275875f507834c6ea6ed0a05f
-#    # Example of a merge of the PR with the number <PR>
-#    # - oca refs/pull/<PR>/head
-#openspp-scripts:
-#  defaults:
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    openspp: https://github.com/openspp/openspp-scripts.git
-#  target: openspp main
-#  merges:
-#    - openspp main
-#app-odoo:
-#  defaults:
-#    depth: $DEPTH_DEFAULT
-#  remotes:
-#    guohuadeng: git@github.com:guohuadeng/app-odoo.git
-#  target: guohuadeng 15.0
-#  merges:
-#      - guohuadeng 15.0
+    - openspp 17.0
+
 muk_addons:
   remotes:
-    muk: https://github.com/muk-it/odoo-modules.git
-  target: muk 17.0
+    muk: https://github.com/OpenSPP/mukit-modules.git
+  target: muk $ODOO_VERSION
   merges:
     - muk 17.0

--- a/setup-devel.yaml
+++ b/setup-devel.yaml
@@ -7,8 +7,6 @@
 #
 #   git clean -ffd
 
-version: "2.4"
-
 services:
   odoo:
     privileged: true
@@ -18,6 +16,7 @@ services:
         AGGREGATE: "false"
         DEPTH_DEFAULT: 100
         ODOO_VERSION: "17.0"
+        ODOO_SOURCE: "odoo/odoo"
         PYTHONOPTIMIZE: ""
         PIP_INSTALL_ODOO: "false"
         CLEAN: "false"


### PR DESCRIPTION
## **Why is this change needed?**

We should create an environment that is as close as possible to what we run on CI (GH actions) and in PROD.

## **How was the change implemented?**

- Adding OpenSPP's pip-requirements to allow for installing all OpenSPP modules on-demand
- Switching to Odoo version (odoo/odoo) used by OpenSPP instead of default (oca/ocb)
- Switching to use OpenSPP's forks of dependency libraries

Also done:
- Cleaning up files touched by the change

## **How to test manually**

1. Check out this branch
2. Run `invoke develop img-pull img-build git-aggregate resetdb start`
3. Validate that you can connect to Odoo and install `openspp_base` (which is using the OpenSPP pip-requirements)