### PR TITLE
Add base to default server_wide_modules

### DIFF
--- a/odoo/custom/conf.d/00-defaults.conf
+++ b/odoo/custom/conf.d/00-defaults.conf
@@ -7,4 +7,4 @@ limit_time_real = 600
 limit_time_real_cron = 600
 db_name =
 workers = 6
-server_wide_modules = web,queue_job
+server_wide_modules = base,web,queue_job


### PR DESCRIPTION
## Why is this change needed?

Base functionalities, like XMLRPC, are not enabled by default

```
"POST /xmlrpc/2/common HTTP/1.1" 404
```

## How was the change implemented?

Add `base` module to `server_wide_modules`

## How to test manually...

1. On a fresh openspp-docker instance, issue an xmlrpc call for authentication or version check
2. Verify that the response is `200`