### PR TITLE
Fix undefined docker compose file version

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -55,12 +55,15 @@ _logger = getLogger(__name__)
 
 def _override_docker_command(service, command, file, orig_file=None):
     # Read config from main file
+    default_compose_file_version = "2.4"
     if orig_file:
         with open(orig_file) as fd:
             orig_docker_config = yaml.safe_load(fd.read())
-            docker_compose_file_version = orig_docker_config.get("version")
+            docker_compose_file_version = orig_docker_config.get(
+                "version", default_compose_file_version
+            )
     else:
-        docker_compose_file_version = "2.4"
+        docker_compose_file_version = default_compose_file_version
     docker_config = {
         "version": docker_compose_file_version,
         "services": {service: {"command": command}},


### PR DESCRIPTION
Running `invoke start --detach --debugpy` results to validating `/var/folders/s9/k99b_nrd0kxdfmmh8f2y0sd80000gn/T/tmpf0uhu53s.yaml: version must be a string` due to compose files existing but version is missing/misconfigured.

This patch fixes it by defining a default.