### PR TITLE
[FIX] add pandas

### DIFF
--- a/odoo/custom/dependencies/pip.txt
+++ b/odoo/custom/dependencies/pip.txt
@@ -41,6 +41,7 @@ jsonschema
 jwcrypto
 numpy>=1.22.2
 pyjwt>=2.4.0
+pandas
 pyproj
 python-magic
 qrcode

--- a/odoo/custom/dependencies/pip.txt
+++ b/odoo/custom/dependencies/pip.txt
@@ -41,7 +41,7 @@ jsonschema
 jwcrypto
 numpy>=1.22.2
 pyjwt>=2.4.0
-pandas
+pandas==2.3.3
 pyproj
 python-magic
 qrcode


### PR DESCRIPTION
`spp_area_base` now uses `pandas` for importing feature. Hence the need to add pandas on pip requirements.